### PR TITLE
composer.json: Remove config.platform.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,7 @@
     "homepage": "https://github.com/Icinga/icinga-php-library",
     "license": "MIT",
     "config": {
-        "sort-packages": true,
-        "platform": {
-            "php": "5.6.3"
-        }
+        "sort-packages": true
     },
     "require": {
         "php": ">=5.6.0",


### PR DESCRIPTION
Composer update will fail if a dependency requires a newer PHP version than the hardcoded one.

refs lippserd/docker-compose-icinga#23